### PR TITLE
chore: update files to be compatible with latest external iso14229 lib

### DIFF
--- a/patches/iso14229-0003-chore-add-posix-version-definition.patch
+++ b/patches/iso14229-0003-chore-add-posix-version-definition.patch
@@ -1,0 +1,15 @@
+diff --git a/iso14229.h b/iso14229.h
+index f146ecf..aa2b664 100644
+--- a/iso14229.h
++++ b/iso14229.h
+@@ -62,6 +62,10 @@ extern "C" {
+ 
+ #if UDS_SYS == UDS_SYS_UNIX
+ 
++#ifdef CONFIG_BOARD_NATIVE_SIM
++#define _POSIX_C_SOURCE 200809L
++#endif  // CONFIG_BOARD_NATIVE_SIM
++
+ #include <assert.h>
+ #include <inttypes.h>
+ #include <stdbool.h>

--- a/samples/uds/src/read_dtc_information.c
+++ b/samples/uds/src/read_dtc_information.c
@@ -32,7 +32,7 @@ UDSErr_t read_dtc_info_check(const struct uds_context *const context,
   // internally before calling this function.
 
   LOG_INF("Reading DT information by status mask: 0x%02X",
-          args->numOfDTCByStatusMaskArgs.mask);
+          args->subFuncArgs.numOfDTCByStatusMaskArgs.mask);
 
   *apply_action = true;
   return UDS_OK;
@@ -51,7 +51,8 @@ UDSErr_t read_dtc_info_action(struct uds_context *const context,
   }
 
   for (uint32_t i = 0; i < ARRAY_SIZE(dtc_records); i++) {
-    if (dtc_records[i].status & args->numOfDTCByStatusMaskArgs.mask) {
+    if (dtc_records[i].status &
+        args->subFuncArgs.numOfDTCByStatusMaskArgs.mask) {
       ret = args->copy(&context->instance->iso14229.server, dtc_records[i].dtc,
                        sizeof(dtc_records[i].dtc));
       if (ret != UDS_OK) {


### PR DESCRIPTION
Currently we worked off of a private branch of the [iso14229 lib](https://github.com/driftregion/iso14229). Since everything is merged into main in the external lib, we can now move the zephyr module up to `main` which lead to some minor compatability issues addressed in this PR.